### PR TITLE
[Chore] Using QThread instead of python threading for expensive data processing.

### DIFF
--- a/src/multiserialviewer/application/application.py
+++ b/src/multiserialviewer/application/application.py
@@ -103,7 +103,7 @@ class Application(QApplication):
             raise Exception(f"{settings.portName} exists already")
 
         receiver = SerialDataReceiver(settings)
-        processor = SerialDataProcessor(receiver.rxQueue)
+        processor = SerialDataProcessor()
         view = self.mainWindow.createSerialViewerWindow(window_title, size=size, position=position)
         view.setHighlighterSettings(self.highlighterSettings)
         ctrl = SerialViewerController(receiver, processor, view)

--- a/src/multiserialviewer/application/serialViewerController.py
+++ b/src/multiserialviewer/application/serialViewerController.py
@@ -16,7 +16,7 @@ class SerialViewerController(QObject):
         self.view: SerialViewerWindow = view
 
         self.view.signal_closed.connect(self.terminate)
-        self.receiver.rawData.connect(self.processor.handleRawData)
+        self.receiver.signal_rawDataAvailable.connect(self.processor.handleRawData)
 
     def start(self) -> bool:
         if self.receiver.openPort():
@@ -24,7 +24,7 @@ class SerialViewerController(QObject):
             self.receiver.start()
 
             self.show_message(f'Opened {self.receiver.getSettings().portName}')
-            self.processor.asciiData.connect(self.view.appendData)
+            self.processor.signal_asciiDataAvailable.connect(self.view.appendData)
             return True
         else:
             self.show_error(f'Failed to open {self.receiver.getSettings().portName}')
@@ -35,7 +35,7 @@ class SerialViewerController(QObject):
             self.receiver.stop()
             self.receiver.closePort()
             self.processor.stop()
-            self.processor.asciiData.disconnect(self.view.appendData)
+            self.processor.signal_asciiDataAvailable.disconnect(self.view.appendData)
             self.show_message(f'Closed {self.receiver.getSettings().portName}')
 
     def show_message(self, text):

--- a/src/multiserialviewer/application/serialViewerController.py
+++ b/src/multiserialviewer/application/serialViewerController.py
@@ -16,6 +16,7 @@ class SerialViewerController(QObject):
         self.view: SerialViewerWindow = view
 
         self.view.signal_closed.connect(self.terminate)
+        self.receiver.rawData.connect(self.processor.handleRawData)
 
     def start(self) -> bool:
         if self.receiver.openPort():
@@ -23,7 +24,7 @@ class SerialViewerController(QObject):
             self.receiver.start()
 
             self.show_message(f'Opened {self.receiver.getSettings().portName}')
-            self.processor.dataAvailable.connect(self.view.appendData)
+            self.processor.asciiData.connect(self.view.appendData)
             return True
         else:
             self.show_error(f'Failed to open {self.receiver.getSettings().portName}')
@@ -34,7 +35,7 @@ class SerialViewerController(QObject):
             self.receiver.stop()
             self.receiver.closePort()
             self.processor.stop()
-            self.processor.dataAvailable.disconnect(self.view.appendData)
+            self.processor.asciiData.disconnect(self.view.appendData)
             self.show_message(f'Closed {self.receiver.getSettings().portName}')
 
     def show_message(self, text):

--- a/src/multiserialviewer/serial_data/serialConnectionSettings.py
+++ b/src/multiserialviewer/serial_data/serialConnectionSettings.py
@@ -7,4 +7,3 @@ class SerialConnectionSettings:
         self.dataBits : QSerialPort.DataBits = QSerialPort.DataBits.Data8
         self.parity : QSerialPort.Parity = QSerialPort.Parity.NoParity
         self.stopbits : QSerialPort.StopBits = QSerialPort.StopBits.OneStop
-        self.timeout = 0.5

--- a/src/multiserialviewer/serial_data/serialDataProcessor.py
+++ b/src/multiserialviewer/serial_data/serialDataProcessor.py
@@ -4,7 +4,7 @@ from PySide6.QtCore import Signal, Slot, QObject, QThread, QByteArray, Qt
 class Processor(QObject):
     asciiData = Signal(str)
 
-    Slot()
+    Slot(QByteArray)
     def handleRawData(self, rawData: QByteArray):
         data : bytearray = bytearray(rawData) 
 

--- a/src/multiserialviewer/serial_data/serialDataProcessor.py
+++ b/src/multiserialviewer/serial_data/serialDataProcessor.py
@@ -1,4 +1,4 @@
-from PySide6.QtCore import Signal, Slot, QObject, QThread, QByteArray, Qt
+from PySide6.QtCore import Signal, Slot, QObject, QThread, QByteArray
 
 
 class SerialDataProcessor(QObject):

--- a/src/multiserialviewer/serial_data/serialDataProcessor.py
+++ b/src/multiserialviewer/serial_data/serialDataProcessor.py
@@ -1,28 +1,13 @@
 from PySide6.QtCore import Signal, Slot, QObject, QThread, QByteArray, Qt
 
 
-class Processor(QObject):
-    asciiData = Signal(str)
-
-    Slot(QByteArray)
-    def handleRawData(self, rawData: QByteArray):
-        data : bytearray = bytearray(rawData) 
-
-        if len(data) > 0:
-            self.asciiData.emit(data.decode(encoding='ascii', errors='ignore'))
-
-
 class SerialDataProcessor(QObject):
-    asciiData: Signal = Signal(str)
-    __rawData: Signal = Signal(QByteArray)
+    signal_asciiDataAvailable: Signal = Signal(str)
 
     def __init__(self):
         super(SerialDataProcessor, self).__init__()
-        self.__worker: Processor = Processor()
         self.__thread: QThread = QThread()
-        self.__worker.moveToThread(self.__thread)
-        self.__rawData.connect(self.__worker.handleRawData, Qt.ConnectionType.QueuedConnection)
-        self.__worker.asciiData.connect(self.__handleAsciiData, Qt.ConnectionType.QueuedConnection)
+        self.moveToThread(self.__thread)
 
     def start(self):
         self.__thread.start()
@@ -31,10 +16,10 @@ class SerialDataProcessor(QObject):
         self.__thread.quit()
         self.__thread.wait()
 
-    Slot(QByteArray)
+    @Slot(QByteArray)
     def handleRawData(self, rawData: QByteArray):
-        self.__rawData.emit(rawData)
+        data : bytearray = bytearray(rawData) 
 
-    Slot(str)
-    def __handleAsciiData(self, asciiData: str):
-        self.asciiData.emit(asciiData)
+        if len(data) > 0:
+            self.signal_asciiDataAvailable.emit(data.decode(encoding='ascii', errors='ignore'))
+

--- a/src/multiserialviewer/serial_data/serialDataProcessor.py
+++ b/src/multiserialviewer/serial_data/serialDataProcessor.py
@@ -1,4 +1,4 @@
-from PySide6.QtCore import Signal, Slot, QObject, QThread, QByteArray
+from PySide6.QtCore import Signal, Slot, QObject, QThread, QByteArray, Qt
 
 
 class Processor(QObject):
@@ -21,8 +21,8 @@ class SerialDataProcessor(QObject):
         self.__worker: Processor = Processor()
         self.__thread: QThread = QThread()
         self.__worker.moveToThread(self.__thread)
-        self.__rawData.connect(self.__worker.handleRawData)
-        self.__worker.asciiData.connect(self.__handleAsciiData)
+        self.__rawData.connect(self.__worker.handleRawData, Qt.ConnectionType.QueuedConnection)
+        self.__worker.asciiData.connect(self.__handleAsciiData, Qt.ConnectionType.QueuedConnection)
 
     def start(self):
         self.__thread.start()

--- a/src/multiserialviewer/serial_data/serialDataReceiver.py
+++ b/src/multiserialviewer/serial_data/serialDataReceiver.py
@@ -1,10 +1,11 @@
 from PySide6.QtSerialPort import QSerialPort
-from PySide6.QtCore import Slot, QObject, QByteArray
-from queue import Queue
+from PySide6.QtCore import Slot, Signal, QObject, QByteArray
 from .serialConnectionSettings import SerialConnectionSettings
 
 
 class SerialDataReceiver(QObject):
+    rawData: Signal = Signal(QByteArray)
+
     def __init__(self, settings: SerialConnectionSettings):
         super(SerialDataReceiver, self).__init__()
         self.__serialPort: QSerialPort = QSerialPort(settings.portName)
@@ -13,7 +14,6 @@ class SerialDataReceiver(QObject):
         self.__serialPort.setStopBits(settings.stopbits)
         self.__serialPort.setDataBits(settings.dataBits)
         self.__settings = settings
-        self.rxQueue = Queue()
 
     def openPort(self) -> bool:
         if not self.__serialPort.isOpen():
@@ -46,5 +46,5 @@ class SerialDataReceiver(QObject):
     def __handleReadableData(self):
         received_data : QByteArray = self.__serialPort.readAll()
         if len(received_data) > 0:
-            self.rxQueue.put(received_data)
+            self.rawData.emit(received_data)
 

--- a/src/multiserialviewer/serial_data/serialDataReceiver.py
+++ b/src/multiserialviewer/serial_data/serialDataReceiver.py
@@ -4,7 +4,7 @@ from .serialConnectionSettings import SerialConnectionSettings
 
 
 class SerialDataReceiver(QObject):
-    rawData: Signal = Signal(QByteArray)
+    signal_rawDataAvailable: Signal = Signal(QByteArray)
 
     def __init__(self, settings: SerialConnectionSettings):
         super(SerialDataReceiver, self).__init__()
@@ -46,5 +46,5 @@ class SerialDataReceiver(QObject):
     def __handleReadableData(self):
         received_data : QByteArray = self.__serialPort.readAll()
         if len(received_data) > 0:
-            self.rawData.emit(received_data)
+            self.signal_rawDataAvailable.emit(received_data)
 


### PR DESCRIPTION
This PR uses QThread instead of pythons "threading" library for data processing. 

Currently the offload into a separate thread might not be necessary as the decoding isn't very resource expensive. But i will keep it for future extensions.